### PR TITLE
Implemented tabs in releases page

### DIFF
--- a/src/scenes/Releases/components/Release/Release.jsx
+++ b/src/scenes/Releases/components/Release/Release.jsx
@@ -3,6 +3,7 @@ import Modal from 'react-responsive-modal';
 import callApi from '@/services/Api/api.js';
 import PropTypes from 'prop-types';
 import { formatDateYMD, formatSeconds } from '@/services/Datetime/Datetime.js';
+import SongTablatures from './components/SongTablatures';
 
 class Release extends React.Component {
   constructor (props) {
@@ -80,10 +81,10 @@ class Release extends React.Component {
   }
 
   /**
-     * Return the download count for a given release.
-     * @param {int} rid is the release ID
-     * @return {int} the amount of downloads
-     */
+   * Return the download count for a given release.
+   * @param {int} rid is the release ID
+   * @return {int} the amount of downloads
+   */
   async getDownloadCount () {
     try {
       const response = await callApi('GET', `/downloads/releases/${this.props.release.id}`, null, null);
@@ -94,10 +95,10 @@ class Release extends React.Component {
   }
 
   /**
-     * Create a nice filename, eg. 2016-devoid of life.zip. All album files are zip files.
-     * @param {datetime} date is the full release date
-     * @param {string} title is the name of the album
-     */
+   * Create a nice filename, eg. 2016-devoid of life.zip. All album files are zip files.
+   * @param {datetime} date is the full release date
+   * @param {string} title is the name of the album
+   */
   getFilename (d, title) {
     const dateObj = new Date(d);
     const year = dateObj.getFullYear();
@@ -155,6 +156,7 @@ class Release extends React.Component {
                       <td>{ song.title }</td>
                       <td>{ formatSeconds(song.duration) }</td>
                       <td><a href='javascript:;' onClick={ () => this.onOpenModal(song.id) }>Lyrics</a></td>
+                      <SongTablatures songId={ song.id } />
                     </tr>
                   );
                 }, this)

--- a/src/scenes/Releases/components/Release/components/SongTablatures.jsx
+++ b/src/scenes/Releases/components/Release/components/SongTablatures.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import callApi from '@/services/Api/api';
+
+class SongTablatures extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      songId: parseInt(this.props.songId) || null,
+      title: '',
+      tabs: []
+    };
+    this.getTabPath = this.getTabPath.bind(this);
+    this.getTabs = this.getTabs.bind(this);
+    this.getTabs(this.state.songId);
+  }
+
+  getTabPath (filename) {
+    return `static/tabs/${filename}`;
+  }
+
+  /**
+   * Get the tabulature info for a given song
+   */
+  async getTabs (songId) {
+    if (songId == null) return 'Invalid song ID';
+    try {
+      const response = await callApi('GET', `/songs/${songId}/tabs`, null, null);
+      this.setState({ title: response.data.songTitle, tabs: response.data.tabs });
+    } catch (err) {
+      return;
+    }
+  }
+
+  render () {
+    return (
+      this.state.tabs.map(tab => {
+        return <td key={ tab.title }><a href={ this.getTabPath(tab.filename) }>{ tab.title }</a></td>;
+      })
+    );
+  }
+}
+
+SongTablatures.propTypes = {
+  songId: PropTypes.number.isRequired
+};
+
+export default SongTablatures;


### PR DESCRIPTION
This will fetch the tabs from the backend for each song. If no tab exists, no text is shown. Otherwise it shows each tab type, eg. Guitar Pro and Text.

After this is merged, the tab files should be added to backend ``static/tabs/filename.ext`` and inserted into the DB table ``SongsTabs``